### PR TITLE
Fixed issue with parsing usernames with a dash

### DIFF
--- a/services/github/project/api/views.py
+++ b/services/github/project/api/views.py
@@ -29,6 +29,7 @@ def ping_pong():
 def is_member(username):
     """Check if user is a member of your GitHub organization"""
     github_org = current_app.config['GITHUB_ORG']
+    username = '"' + username + '"'
     query = f"""query {{
         user(login:{username}){{
             organization(login:{github_org}) {{


### PR DESCRIPTION
When sending a username with a dash in GraphQL you need to surround it with quotes. Otherwise, it takes it as a subtraction.