### PR TITLE
Add closedAt timestamp, pin specific Docker versions

### DIFF
--- a/examples/closed_prs.py
+++ b/examples/closed_prs.py
@@ -22,9 +22,9 @@ for org in ALL_REPOS:
     for repo in ALL_REPOS[org]:
         items = get_items(org, repo, 'pull_requests')
         for item in items:
-            updated_at = datetime.datetime.strptime(item['updatedAt'], '%Y-%m-%dT%H:%M:%SZ')
+            closed_at = datetime.datetime.strptime(item['closedAt'], '%Y-%m-%dT%H:%M:%SZ')
             text = "{}, {} , {}, {}, {}".format(repo, item['url'], item['points'],
-                                                item['reviewer_points'], updated_at.date())
+                                                item['reviewer_points'], closed_at.date())
             print(text)
             total_closed_prs = total_closed_prs + 1
 

--- a/services/client-react/Dockerfile-dev
+++ b/services/client-react/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:10.16
 
 # set working directory
 RUN mkdir /usr/src/app

--- a/services/github/Dockerfile
+++ b/services/github/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.7
 
 # set working directory
 RUN mkdir -p /usr/src/app

--- a/services/github/project/api/graphql.py
+++ b/services/github/project/api/graphql.py
@@ -77,6 +77,7 @@ class GraphQL(object):
                             title
                             createdAt
                             updatedAt
+                            closedAt
                             {self.review}
                             author {{
                                 login

--- a/services/github/project/api/routes.py
+++ b/services/github/project/api/routes.py
@@ -185,6 +185,7 @@ def get_items():
                     'title': r.get('title'),
                     'createdAt': r.get('createdAt'),
                     'updatedAt': r.get('updatedAt'),
+                    'closedAt': r.get('closedAt'),
                     'author': get_author(r) or 'unknown',
                     'num_reactions': r.get('reactions').get('totalCount') or 0,
                     'num_comments': r.get('comments').get('totalCount') or 0,

--- a/services/hacktoberfest/Dockerfile-dev
+++ b/services/hacktoberfest/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.7
 
 # install environment dependencies
 RUN apt-get update -yqq \

--- a/services/looker/Dockerfile-dev
+++ b/services/looker/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.7
 
 # install environment dependencies
 RUN apt-get update -yqq \

--- a/services/looker/Dockerfile-prod
+++ b/services/looker/Dockerfile-prod
@@ -1,5 +1,5 @@
 # base image
-FROM python:3
+FROM python:3.7
 
 # install dependencies
 RUN apk update && \

--- a/services/tasks/Dockerfile-dev
+++ b/services/tasks/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.7
 
 # install environment dependencies
 RUN apt-get update -yqq \

--- a/services/users/Dockerfile-dev
+++ b/services/users/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.7
 
 # install environment dependencies
 RUN apt-get update -yqq \


### PR DESCRIPTION
* Added closedAt timestamp.
* Pin Dockerfile versions (discovered that the latest image of Python 3 had some [Debian issues](https://unix.stackexchange.com/questions/2544/how-to-work-around-release-file-expired-problem-on-a-local-mirror))