### PR TITLE
docs: retrieve merged and closed PRs vs. only closed PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ We believe in open source and want to give credit where it's due. We used an ama
 
 * Virtual Box
 * Docker
+* Python 3
 
 ## Usage - Local
 
@@ -168,6 +169,18 @@ python ./examples/code_review.py
 
 ```bash
 python ./examples/releases.py
+```
+
+#### Retrieve all closed issues
+
+```bash
+python ./examples/closed_issues.py
+```
+
+#### Retrieve all closed and merged PRs
+
+```bash
+python ./examples/closed_and_merged_prs.py
 ```
 
 ## Usage - Cloud

--- a/examples/closed_and_merged_prs.py
+++ b/examples/closed_and_merged_prs.py
@@ -10,7 +10,7 @@ def get_items(org, repo, item_type):
         "org": org,
         "repo": repo,
         "item_type": item_type,
-        "states[]": ['CLOSED'],
+        "states[]": ['MERGED', 'CLOSED'],
         "limit[]": ['first', '100']
     }
     response = client.github.items.get(query_params=query_params)
@@ -23,8 +23,7 @@ for org in ALL_REPOS:
         items = get_items(org, repo, 'pull_requests')
         for item in items:
             closed_at = datetime.datetime.strptime(item['closedAt'], '%Y-%m-%dT%H:%M:%SZ')
-            text = "{}, {} , {}, {}, {}".format(repo, item['url'], item['points'],
-                                                item['reviewer_points'], closed_at.date())
+            text = "{}, {} , {}, {}".format(repo, item['url'], closed_at.date(), item['author'])
             print(text)
             total_closed_prs = total_closed_prs + 1
 

--- a/examples/closed_issues.py
+++ b/examples/closed_issues.py
@@ -22,7 +22,7 @@ for org in ALL_REPOS:
     for repo in ALL_REPOS[org]:
         items = get_items(org, repo, 'issues')
         for item in items:
-            updated_at = datetime.datetime.strptime(item['updatedAt'], '%Y-%m-%dT%H:%M:%SZ')
+            updated_at = datetime.datetime.strptime(item['closedAt'], '%Y-%m-%dT%H:%M:%SZ')
             text = "{}, {} , {}".format(repo, item['url'], updated_at.date())
             print(text)
             total_closed_issues = total_closed_issues + 1

--- a/services/github/project/api/graphql.py
+++ b/services/github/project/api/graphql.py
@@ -78,6 +78,7 @@ class GraphQL(object):
                             createdAt
                             updatedAt
                             closedAt
+                            mergedAt
                             {self.review}
                             author {{
                                 login


### PR DESCRIPTION
* Added Python 3 requirement (for running the local example scripts)
* Updated README to include report generation examples
* When reporting on closed issues, we should use the `closedAt` vs `updatedAt` timestamp since the `updatedAt` timestamp can get modified after the issue is already closed.
* When reporting on closed PRs, we also want to included the `MERGED` state since the `CLOSED` state only returns closed, but un-merged results.