### PR TITLE
fix: treat admin PR comments like unapproved review events

### DIFF
--- a/examples/action_items.py
+++ b/examples/action_items.py
@@ -153,4 +153,4 @@ def get_open_items(org: str, repo: str, start_date: str):
 
 
 if __name__ == '__main__':
-    ActionItemsCollector().run(start_date='2018-10-30')
+    ActionItemsCollector().run(start_date='2018-10-20')

--- a/examples/common/issue.py
+++ b/examples/common/issue.py
@@ -172,6 +172,10 @@ class Issue:
                 self.add_response_time(self.last_community_comment, comment)
                 self.last_community_comment = None
 
+            if self.is_pr:
+                # Treat admin PR comments like unapproved review events.
+                self.waiting_for_feedback = comment
+
         else:
             if self.last_admin_comment:
                 self.last_community_comment = comment


### PR DESCRIPTION
Admins leaving a comment on a PR is now effectively the equivalent of leaving an unapproved review (i.e., I should be able to leave a high-level comment and wait for author feedback). Also, expands the action items collection range.