### PR TITLE
fix: only treat non-admin commits as comments if the checks passed

### DIFF
--- a/examples/common/issue.py
+++ b/examples/common/issue.py
@@ -147,9 +147,12 @@ class Issue:
         commit = commit_event['commit']
 
         if get_author(commit) not in ADMINS:
-            self.comment(commit)
             status = commit['status'] or {}
             self.checks_passed = commit if status.get('state') == 'SUCCESS' else None
+
+            # Only treat this as a comment if the checks passed.
+            if self.checks_passed:
+                self.comment(commit)
 
     def review(self, review_event: Dict) -> None:
         if get_author(review_event) in ADMINS:


### PR DESCRIPTION
This makes issues look like they're waiting for feedback instead of a response from the admins.