### PR TITLE
fix: fallback to 'statusCheckRollup' in case of missing 'status'

### DIFF
--- a/examples/action_items.py
+++ b/examples/action_items.py
@@ -170,7 +170,7 @@ def get_open_items(org: str, repo: str):
             'additional_event_names': ['PULL_REQUEST_COMMIT', 'PULL_REQUEST_REVIEW',
                                        'MERGED_EVENT'],
             'additional_event_types': [
-                '... on PullRequestCommit {commit {committedDate author {user {login}} status {state}}}',
+                '... on PullRequestCommit {commit {committedDate author {user {login}} status {state} statusCheckRollup {state}}}',
                 '... on PullRequestReview {createdAt state author {login}}',
                 '... on MergedEvent {createdAt}']
         }

--- a/examples/metrics.py
+++ b/examples/metrics.py
@@ -251,7 +251,7 @@ def get_repo_issues(org: str, repo: str):
             'additional_event_names': ['PULL_REQUEST_COMMIT', 'PULL_REQUEST_REVIEW',
                                        'MERGED_EVENT'],
             'additional_event_types': [
-                '... on PullRequestCommit {commit {committedDate author {user {login}} status {state}}}',
+                '... on PullRequestCommit {commit {committedDate author {user {login}} status {state} statusCheckRollup {state}}}',
                 '... on PullRequestReview {createdAt state author {login}}',
                 '... on MergedEvent {createdAt}']
         }


### PR DESCRIPTION
https://github.community/t/graphql-api-response-for-commit-status-is-null/