### PR TITLE
fix: malformed api query

### DIFF
--- a/examples/common/issue.py
+++ b/examples/common/issue.py
@@ -291,7 +291,8 @@ def get_issues(org: str, repo: str, fragments: str,
 query{{
     search(type: ISSUE,
            first: 50,
-           query: "{issue_type} {issue_state} %cursor% created:{start_date}..{end_date} repo:{org}/{repo}") {{
+           %cursor%,
+           query: "{issue_type} {issue_state} created:{start_date}..{end_date} repo:{org}/{repo}") {{
         nodes {{
             __typename
             {fragments}

--- a/examples/common/issue.py
+++ b/examples/common/issue.py
@@ -291,10 +291,7 @@ def get_issues(org: str, repo: str, fragments: str,
 query{{
     search(type: ISSUE,
            first: 50,
-           %cursor%,
-           query: "{issue_type} {issue_state}
-                   created:{start_date}..{end_date}
-                   repo:{org}/{repo}") {{
+           query: "{issue_type} {issue_state} %cursor% created:{start_date}..{end_date} repo:{org}/{repo}") {{
         nodes {{
             __typename
             {fragments}


### PR DESCRIPTION
Verified this fix produces the correct output locally. Prior to the fix, there was a syntax error that was not surfaced, causing the output of this script to be empty. The issue was found by taking the query produces from the `action_items.py` script and running the query directly [here](https://docs.github.com/en/graphql/overview/explorer).

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
