### PR TITLE
fix: use the closedAt property to determine if an item is still open

### DIFF
--- a/examples/action_items.py
+++ b/examples/action_items.py
@@ -133,6 +133,7 @@ def get_open_items(org: str, repo: str):
         login
     }
     createdAt
+    closedAt
     url
     reactions(content: THUMBS_UP) {
       totalCount

--- a/examples/closed_items.py
+++ b/examples/closed_items.py
@@ -57,6 +57,7 @@ def get_closed_items(org: str, repo: str):
         login
     }
     createdAt
+    closedAt
     url
     timelineItems(first: 100, itemTypes: [CLOSED_EVENT]) {
         nodes {

--- a/examples/common/issue.py
+++ b/examples/common/issue.py
@@ -30,6 +30,7 @@ class Issue:
             self.author = get_author(issue_json)
             self.type = issue_json['__typename']
             self.created_at = issue_json['createdAt']
+            self.closed_at = issue_json['closedAt']
             self.url = issue_json['url']
             self.reaction_count = issue_json.get('reactions', {}).get('totalCount')
 
@@ -74,7 +75,7 @@ class Issue:
                     action = event_type_map[event_type]
                     action(event)
 
-            if not self.closed and not self.merged:
+            if self.is_open():
                 if 'time_to_contact' not in self.metrics and 'time_to_contact_pr' not in self.metrics:
                     if self.is_pr:
                         if self.checks_passed:
@@ -227,6 +228,9 @@ class Issue:
         if metric_id not in self.metrics or multi:
             self.metrics[metric_id] = self.metrics.get(metric_id, [])
             self.metrics[metric_id].append(get_delta_days(start, end))
+
+    def is_open(self) -> bool:
+        return self.closed_at is None or self.closed_at > self.end_date
 
     @property
     def last_event(self):

--- a/examples/metrics.py
+++ b/examples/metrics.py
@@ -166,7 +166,7 @@ class MetricCollector:
             else:
                 last_update = issue.created_at
 
-            if not issue.closed and last_update > stale_date:
+            if issue.is_open() and last_update > stale_date:
                 time_open = get_delta_days(issue.created_at, end_date)
                 if '/pull/' in issue.url:
                     pr_count += 1
@@ -232,6 +232,7 @@ def get_repo_issues(org: str, repo: str):
         login
     }
     createdAt
+    closedAt
     url
     timelineItems(first: 100, itemTypes: [LABELED_EVENT UNLABELED_EVENT
                                           ISSUE_COMMENT

--- a/examples/opened_items.py
+++ b/examples/opened_items.py
@@ -47,6 +47,7 @@ def get_opened_items(org: str, repo: str, start_date: str, end_date: str):
         login
     }
     createdAt
+    closedAt
     url
 }
 ... on PullRequest {

--- a/tests/test_issue.py
+++ b/tests/test_issue.py
@@ -1,0 +1,49 @@
+import unittest
+
+from examples.common.issue import Issue
+
+
+class TestIssue(unittest.TestCase):
+
+    def test_closed_pr_without_closed_event(self):
+        issue_json = {
+            '__typename': 'PullRequest',
+            'author': {
+                'login': 'arthur'
+            },
+            'createdAt': '2022-01-01T00:00:00Z',
+            'closedAt': '2022-02-01T00:00:00Z',
+            'url': 'https://github.com/twilio/twilio-node/pull/765',
+            'state': 'CLOSED',
+            'timelineItems': {
+                'nodes': [
+                    {
+                        '__typename': 'PullRequestCommit',
+                        'commit': {
+                            'committedDate': '2022-01-01T00:00:00Z',
+                            'author': {
+                                'user': {
+                                    'login': 'arthur'
+                                }
+                            },
+                            'status': None,
+                            'statusCheckRollup': {
+                                'state': 'SUCCESS'
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+        issue = Issue(issue_json, '2022-01-10T00:00:00Z')
+        issue.process_events()
+        self.assertTrue(issue.is_open())
+        self.assertTrue(self.is_awaiting(issue))
+
+        issue = Issue(issue_json, '2022-02-01T00:00:00Z')
+        issue.process_events()
+        self.assertFalse(issue.is_open())
+        self.assertFalse(self.is_awaiting(issue))
+
+    def is_awaiting(self, issue: Issue) -> bool:
+        return any(metric for metric in issue.metrics if metric.startswith('time_awaiting'))


### PR DESCRIPTION
This is a workaround to handle certain issues like https://github.com/twilio/twilio-node/pull/765 which is CLOSED but does not have a CLOSED_EVENT in its timeline.

API response snippet:
```json
     {
          "__typename": "PullRequest",
          "author": {
            "login": "bishal7679"
          },
          "createdAt": "2022-06-22T04:02:47Z",
          "closedAt": "2022-06-22T04:10:10Z",
          "mergedAt": null,
          "url": "https://github.com/twilio/twilio-node/pull/765",
          "state": "CLOSED",
          "timelineItems": {
            "nodes": [
              {
                "__typename": "PullRequestCommit",
                "commit": {
                  "committedDate": "2022-06-22T03:59:45Z",
                  "author": {
                    "user": {
                      "login": "bishal7679"
                    }
                  },
                  "status": null,
                  "statusCheckRollup": {
                    "state": "SUCCESS"
                  }
                }
              }
            ]
          }
        },
```